### PR TITLE
Adding plugin header info for GitHub Updater.

### DIFF
--- a/contact-form-7-db.php
+++ b/contact-form-7-db.php
@@ -7,6 +7,8 @@
    Description: Save form submissions to the database from <a href="http://wordpress.org/extend/plugins/contact-form-7/">Contact Form 7</a>, <a href="http://wordpress.org/extend/plugins/si-contact-form/">Fast Secure Contact Form</a>, <a href="http://wordpress.org/extend/plugins/jetpack/">JetPack Contact Form</a> and <a href="http://www.gravityforms.com">Gravity Forms</a>. Includes exports and short codes. | <a href="admin.php?page=CF7DBPluginSubmissions">Data</a> | <a href="admin.php?page=CF7DBPluginShortCodeBuilder">Short Codes</a> | <a href="admin.php?page=CF7DBPluginSettings">Settings</a> | <a href="http://cfdbplugin.com/">Reference</a>
    Text Domain: contact-form-7-to-database-extension
    License: GPL3
+   GitHub Plugin URI: https://github.com/mdsimpson/contact-form-7-to-database-extension
+   GitHub Branch: master
   */
 
 


### PR DESCRIPTION
This pull request adds the plugin header information needed by GitHub Updater so it can check for and pull updates from GitHub.

Addresses issue #3.