### PR TITLE
adding option to save the [_url] tag in the database

### DIFF
--- a/CF7DBPlugin.php
+++ b/CF7DBPlugin.php
@@ -53,6 +53,7 @@ class CF7DBPlugin extends CF7DBPluginLifeCycle implements CFDBDateFormatter {
                 'IntegrateWithCF7' =>  array('<a target="_cf7" href="https://wordpress.org/plugins/contact-form-7/">Contact Form 7</a>', 'true', 'false'),
                 'IntegrateWithCF7SavePageTitle' => array('&#x21B3; ' . __('Save Page Title from Contact Form 7 submissions', 'contact-form-7-to-database-extension'), 'false', 'true'),
                 'IntegrateWithCF7SavePageUrl' => array(__('&#x21B3; ' . 'Save Page URL from Contact Form 7 submissions', 'contact-form-7-to-database-extension'), 'false', 'true'),
+                'IntegrateWithCF7SaveSubmittedPageUrl' => array(__('&#x21B3; ' . 'Save Submitted From Page URL from Contact Form 7 submissions', 'contact-form-7-to-database-extension'), 'false', 'true'),
                 'GenerateSubmitTimeInCF7Email' => array(__('&#x21B3; ' . 'Generate [submit_time] tag for Contact Form 7 email', 'contact-form-7-to-database-extension'), 'false', 'true'),
                 'IntegrateWithCalderaForms' => array('<a target="_caldera" href="https://wordpress.org/plugins/caldera-forms/">Caldera Forms</a>', 'true', 'false'),
                 'IntegrateWithCFormsII' => array('<a target="_cf2" href="https://wordpress.org/plugins/cforms2/">CformsII</a>', 'true', 'false'),

--- a/CFDBIntegrationContactForm7.php
+++ b/CFDBIntegrationContactForm7.php
@@ -82,6 +82,9 @@ class CFDBIntegrationContactForm7 {
                 if ('true' == $this->plugin->getOption('IntegrateWithCF7SavePageUrl', 'false', true)) {
                     $data['posted_data']['Page URL'] = wpcf7_special_mail_tag('', '_post_url', '');
                 }
+                if ('true' == $this->plugin->getOption('IntegrateWithCF7SaveSubmittedPageUrl', 'false', true)) {
+                    $data['posted_data']['Submitted from Page URL'] = wpcf7_special_mail_tag('', '_url', '');
+                }
 
                 return (object) $data;
             }


### PR DESCRIPTION
It's a small change. I ran into a situation where I needed the actual submitted URL, which is captured by Contact Form 7 through the tag [_url]. The importance for it is that [_url] will contain query strings that may be present when the form is submitted, and we needed to see these query strings to identify use-cases with form submissions from the user.

Added the option in the admin to toggle it on, and added it to the options to be saved if its set to true.