### PR TITLE
Added like operator to export filter

### DIFF
--- a/CFDBFilterParser.php
+++ b/CFDBFilterParser.php
@@ -142,7 +142,7 @@ class CFDBFilterParser extends CFDBParserBase implements CFDBEvaluator {
         // Sometimes get HTML codes for greater-than and less-than; replace them with actual symbols
         $comparisonExpression = str_replace('&gt;', '>', $comparisonExpression);
         $comparisonExpression = str_replace('&lt;', '<', $comparisonExpression);
-        return preg_split('/(===)|(==)|(=)|(!==)|(!=)|(<>)|(<=)|(<)|(>=)|(>)|(~~)|(\[in\])|(\[!in\])/',
+        return preg_split('/(===)|(==)|(=)|(!==)|(!=)|(<>)|(<=)|(<)|(>=)|(>)|(~~)|(\[like\])|(\[in\])|(\[!in\])/',
                 $comparisonExpression, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
     }
 
@@ -288,6 +288,16 @@ class CFDBFilterParser extends CFDBParserBase implements CFDBEvaluator {
 
             case '<=':
                 $retVal = $left <= $right;
+                break;
+
+            case '[like]':
+                $left = str_replace(' ', '', $left);
+                $pos = strpos($left, ',');
+                if ($pos === false) {
+                    $retVal = $left == $right;
+                } else {
+                    $retVal = in_array($right, explode(',', $left));
+                }
                 break;
 
             case '~~':

--- a/CFDBViewShortCodeBuilder.php
+++ b/CFDBViewShortCodeBuilder.php
@@ -402,6 +402,7 @@ class CFDBViewShortCodeBuilder extends CFDBView {
                     <option value="<="><=</option>
                     <option value="===">===</option>
                     <option value="!==">!==</option>
+                    <option value="[like]">[like]</option>
                     <option value="~~">~~</option>
                     <option value="[in]">[in]</option>
                     <option value="[!in]">[!in]</option>


### PR DESCRIPTION
Added a Like operator for use in the export filter.
This way you can check if a given value is in a list of comma separated values.

This can be useful if you are using the download monitor plugin with multiple downloads. The CF7 field for this gives a comma separated list of values, and now you can easily filter on records that downloaded a specific file.