### PR TITLE
Changed Page URL and Page Title convert data functions to wpcf7_post_…

### DIFF
--- a/CF7DBPlugin.php
+++ b/CF7DBPlugin.php
@@ -1140,6 +1140,7 @@ class CF7DBPlugin extends CF7DBPluginLifeCycle implements CFDBDateFormatter {
             $exp = new ExportEntry();
             if (isset($_REQUEST['form_name']) && !empty($_REQUEST['form_name'])) {
                 $form = stripslashes($_REQUEST['form_name']);
+                $form =  preg_replace('/[^[:alnum:][:space:]]/u', '',$form);
             } else {
                 global $wpdb;
                 $table = $this->getSubmitsTableName();

--- a/CFDBIntegrationContactForm7.php
+++ b/CFDBIntegrationContactForm7.php
@@ -77,13 +77,13 @@ class CFDBIntegrationContactForm7 {
                 $data['WPCF7_ContactForm'] = $cf7;
 
                 if ('true' == $this->plugin->getOption('IntegrateWithCF7SavePageTitle', 'false', true)) {
-                    $data['posted_data']['Page Title'] = wpcf7_special_mail_tag('', '_post_title', '');
+                    $data['posted_data']['Page Title'] = wpcf7_post_related_smt('', '_post_title', '');
                 }
                 if ('true' == $this->plugin->getOption('IntegrateWithCF7SavePageUrl', 'false', true)) {
-                    $data['posted_data']['Page URL'] = wpcf7_special_mail_tag('', '_post_url', '');
+                    $data['posted_data']['Page URL'] = wpcf7_post_related_smt('', '_post_url', '');
                 }
                 if ('true' == $this->plugin->getOption('IntegrateWithCF7SaveSubmittedPageUrl', 'false', true)) {
-                    $data['posted_data']['Submitted from Page URL'] = wpcf7_special_mail_tag('', '_url', '');
+                    $data['posted_data']['Submitted Page URL'] = wpcf7_special_mail_tag('', '_url', '');
                 }
 
                 return (object) $data;

--- a/CFDBViewWhatsInDB.php
+++ b/CFDBViewWhatsInDB.php
@@ -64,6 +64,7 @@ class CFDBViewWhatsInDB extends CFDBView {
         if ($currSelection) {
             $currSelection = stripslashes($currSelection);
             $currSelection = htmlspecialchars_decode($currSelection, ENT_QUOTES);
+            $currSelection =  preg_replace('/[^[:alnum:][:space:]]/u', '',$currSelection);
         }
 
         // Sanitized version of $currSelection for display on the page


### PR DESCRIPTION
Changed Page URL and Page Title convert data functions to <code>wpcf7_post_related_smt</code>

Changed Submitted from Page URL to Submitted Page URL because otherwise <code>$wpdb->get_results</code> parses  <code>max(if(`field_name`='Submitted from Page URL', `field_value`, null )) AS 'Submitted from Page URL'</code>, incorrectly (from is used as mysql statement)

Note: for live installations with submitted form data you would need to execute following sql statement:
<code>UPDATE `wp_cf7dbplugin_submits` SET `field_name`='Submitted Page URL' WHERE field_name='Submitted from URL'</code>
