### PR TITLE
Fix issue #94

### DIFF
--- a/CF7DBPlugin.php
+++ b/CF7DBPlugin.php
@@ -846,7 +846,7 @@ class CF7DBPlugin extends CF7DBPluginLifeCycle implements CFDBDateFormatter {
                     continue; // Don't save in DB
                 }
 
-                $value = is_array($value) ? implode($value, ', ') : $value;
+                $value = is_array($value) ? implode( ', ',$value) : $value;
                 $valueClean = stripslashes($value);
 
                 // Check if this is a file upload field


### PR DESCRIPTION
Issue Detail:
[PHP 8.0] implode(): Argument #2 ($array) must be of type ?array
Fix:
Fix syntax of implode on line 849.